### PR TITLE
Use local ExpressJS asset

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Developer Portfolio
+
+React-based personal portfolio website.
+
+## Requirements
+- Node.js 22.x
+- npm
+
+## Install dependencies
+```bash
+npm install
+```
+
+## Run development server
+```bash
+npm start
+```
+
+## Run tests
+```bash
+npm test -- --watchAll=false
+```
+
+## Build for production
+```bash
+npm run build
+```
+
+The project uses `.npmrc` with `legacy-peer-deps=true` to resolve peer dependency conflicts during installation.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "engines": {
+    "node": "22.x"
+  },
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/src/components/Skills/Skills.jsx
+++ b/src/components/Skills/Skills.jsx
@@ -36,7 +36,7 @@ function Skills() {
                     >
                         {skillsData.map((skill, id) => (
                             <div className="skill--box" key={id} style={skillBoxStyle}>
-                                <img src={ skill==="ExpressJS" ?  "https://blog.amt.in/wp-content/uploads/2017/12/e16da876-c2fd-4eb8-ae72-4b193c534938-Edited.png" :skillsImage(skill)} alt={skill} />
+                                <img src={skillsImage(skill)} alt={skill} />
                                 <h3 style={{color: theme.tertiary}}>
                                     {skill}
                                 </h3>

--- a/src/utils/skillsImage.js
+++ b/src/utils/skillsImage.js
@@ -59,7 +59,7 @@ import tensorflow from '../assets/svg/skills/tensorflow.svg'
 import webix from '../assets/svg/skills/webix.svg'
 import wordpress from '../assets/svg/skills/wordpress.svg'
 import nodejs from '../assets/svg/skills/nodejs.svg'
-import ExpressJS from '../assets/svg/skills/expressjsss.svg'
+import ExpressJS from '../assets/svg/skills/ExpressJS.png'
 
 import azure from '../assets/svg/skills/azure.svg'
 import blender from '../assets/svg/skills/blender.svg'
@@ -143,8 +143,8 @@ export const skillsImage = (skill) => {
             return cplusplus;
         case 'c#':
             return csharp;
-        case ExpressJS:
-            return 'ExpressJS';
+        case 'expressjs':
+            return ExpressJS;
         case 'dart':
             return dart;
         case 'go':


### PR DESCRIPTION
## Summary
- import ExpressJS logo from the project assets and handle it with a normal case in `skillsImage`
- simplify `Skills` component to rely on `skillsImage` without ExpressJS workaround

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a80d25598083238e6d1a5e3babeede